### PR TITLE
fixed error handling on signup form

### DIFF
--- a/app/forms/signup_form.py
+++ b/app/forms/signup_form.py
@@ -11,8 +11,15 @@ def user_exists(form, field):
     if user:
         raise ValidationError("User is already registered.")
 
+def username_exists(form, field):
+    print('check fs username exists', field.data)
+    username = field.data
+    user = User.query.filter(User.username == username).first()
+    if user:
+        raise ValidationError("Username Taken")
+
 
 class SignUpForm(FlaskForm):
-    username = StringField('username', validators=[DataRequired()])
+    username = StringField('username', validators=[DataRequired(), username_exists])
     email = StringField('email', validators=[DataRequired(), user_exists])
     password = StringField('password', validators=[DataRequired()])

--- a/app/forms/signup_form.py
+++ b/app/forms/signup_form.py
@@ -12,7 +12,7 @@ def user_exists(form, field):
         raise ValidationError("User is already registered.")
 
 def username_exists(form, field):
-    print('check fs username exists', field.data)
+    print('check if username exists', field.data)
     username = field.data
     user = User.query.filter(User.username == username).first()
     if user:


### PR DESCRIPTION
Currently, the Signup form is only checking if email already exists in the database.
If a new email entered with an already existing username, the signup route throws 500 internal server error