### PR TITLE
Remove 401 for unsuccessful restore and add 401 for unsuccessful signup

### DIFF
--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -25,7 +25,7 @@ def authenticate():
     """
     if current_user.is_authenticated:
         return current_user.to_dict()
-    return {'errors': ['Unauthorized']}, 401
+    return {'errors': ['Unauthorized']}
 
 
 @auth_routes.route('/login', methods=['POST'])
@@ -72,7 +72,7 @@ def sign_up():
         db.session.commit()
         login_user(user)
         return user.to_dict()
-    return {'errors': validation_errors_to_error_messages(form.errors)}
+    return {'errors': validation_errors_to_error_messages(form.errors)}, 401
 
 
 @auth_routes.route('/unauthorized')


### PR DESCRIPTION
The restore user api was sending a 401 if there was not a user previously logged in, which caused an error in the console on initial app load, it was changed to 200.

Also, the signup route was sending a 200 on an unsuccessful signup so it was changed to 401.